### PR TITLE
Provide option to `stop`, `warn` or `log` when pull/checkout fails

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -13,16 +13,17 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        r-version: ['4.2.2']
+        r-version: ['release']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -27,6 +27,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install system dependencies for devtools
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libxml2-dev
+
       - name: Set up R ${{ matrix.r-version }}
         uses: r-lib/actions/setup-r@v2
         with:
@@ -37,6 +43,7 @@ jobs:
         run: |
           install.packages("devtools")
         shell: Rscript {0}
+
       - name: Check
         run: devtools::check()
         shell: Rscript {0}

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         r-version: ['release']

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -28,9 +28,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up R ${{ matrix.r-version }}
-        uses: r-lib/actions/setup-r@f57f1301a053485946083d7a45022b278929a78a
+        uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.r-version }}
+          use-public-rspm: true
+
       - name: Install dependencies
         run: |
           install.packages("devtools")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: multiloadr
 Type: Package
 Title: Load the packages relevant to a project within a session
-Version: 0.0.1
+Version: 0.0.1.9000
 Authors@R: person("Dony", "Unardi", email = "donyunardi@gmail.com", role = c("aut", "cre"))
 Description: The purpose of this package is to assist in loading the R packages that serve as
     immediate dependencies for the R package currently being worked on. This package is useful for

--- a/R/load_pkgs.R
+++ b/R/load_pkgs.R
@@ -115,14 +115,13 @@ load_pkgs <- function(
               pkg, "\033[0m\n",
               " \033[0;91mPlease check your local changes. \033[0m"
             )
-            )
             switch(load_verbose,
               error = stop(message),
               warning = warning(message, immediate. = TRUE),
               silent = invisible(),
               cat(message)
             )
-
+          }
           break
         } else {
           cat(
@@ -168,17 +167,17 @@ load_pkgs <- function(
           )
           if (pull_error) {
             message <- paste(
-              "\033[0;91m`git pull` failed.",
+              "\033[0;91mCan't pull then", branch, "branch for\033[0;94m",
+              pkg, "\033[0m\n",
               "Please check your local changes for\033[0;94m",
               pkg, "\033[0m\n"
             )
-            if (load_verbose == "error") {
-              stop(message)
-            } else if (load_verbose == "warning") {
-              warning(message)
-            } else if (load_verbose != "silent") {
+            switch(load_verbose,
+              error = stop(message),
+              warning = warning(message, immediate. = TRUE),
+              silent = invisible(),
               cat(message)
-            }
+            )
           }
         } else {
           cat("Remote URL does not exist...\n")

--- a/R/load_pkgs.R
+++ b/R/load_pkgs.R
@@ -167,7 +167,7 @@ load_pkgs <- function(
           )
           if (pull_error) {
             message <- paste(
-              "\033[0;91mCan't pull then", branch, "branch for\033[0;94m",
+              "\033[0;91mCan't pull the", branch, "branch for\033[0;94m",
               pkg, "\033[0m\n",
               "Please check your local changes for\033[0;94m",
               pkg, "\033[0m\n"

--- a/R/load_pkgs.R
+++ b/R/load_pkgs.R
@@ -115,14 +115,12 @@ load_pkgs <- function(
               "Please check your local changes for\033[0;94m",
               pkg, "\033[0m\n"
             )
-            if (load_verbose == "error") {
-              stop(message)
-            } else if (load_verbose == "warning") {
-              warning(message)
-            } else if (load_verbose != "silent") {
+            switch(load_verbose,
+              error = stop(message),
+              warning = warning(message, immediate. = TRUE),
+              silent = invisible(),
               cat(message)
-            }
-          }
+            )
 
           break
         } else {

--- a/R/load_pkgs.R
+++ b/R/load_pkgs.R
@@ -111,9 +111,10 @@ load_pkgs <- function(
           )
           if (checkout_error) {
             message <- paste(
-              "\033[0;91m`git checkout` failed.",
-              "Please check your local changes for\033[0;94m",
-              pkg, "\033[0m\n"
+              "\033[0;91mCan't switch to", branch, "branch for\033[0;94m",
+              pkg, "\033[0m\n",
+              " \033[0;91mPlease check your local changes. \033[0m"
+            )
             )
             switch(load_verbose,
               error = stop(message),

--- a/R/load_pkgs.R
+++ b/R/load_pkgs.R
@@ -13,12 +13,21 @@
 #' to load. Defaults to \code{NULL}. The first branch that is found will be
 #' loaded for each package. If it is NULL or non-existent, it will be loaded
 #' from the presently active branch.
+#' If local changes make checkout unsuccessful, the function will produce error.
 #'
 #' @param git_pull A logical value (TRUE/FALSE) indicating whether to perform a
 #' `git pull` before loading the package. Defaults to \code{FALSE}.
+#' If local changes make pull unsuccessful, the function will produce error.
 #'
 #' @param from_commit A named list indicating the commit hash to load for each
 #' package.
+#'
+#' @param load_verbose Default: `warning` A string that sets
+#' how should a pull/checkout failure be reported.
+#' `error` for stopping with an error,
+#' `warning` to show warning and continue,
+#' `message`/unset for just logging the git failure.
+#' Default value can be set with `options('multiloadr.load.verbose' = 'error')`.
 #'
 #' @return This function returns nothing, but prints a message indicating which
 #' packages were loaded and from which branch.
@@ -27,30 +36,30 @@
 #'
 #' @examples
 #' if (interactive()) {
-#' add_pkgs("packageA", "/path/to/packageA")
-#' add_pkgs("packageB", "/path/to/packageB")
+#'   add_pkgs("packageA", "/path/to/packageA")
+#'   add_pkgs("packageB", "/path/to/packageB")
 #'
-#' # Load packages without switching branch
-#' load_pkgs()
+#'   # Load packages without switching branch
+#'   load_pkgs()
 #'
-#' # Switch to "develop" branch and load packages
-#' load_pkgs(branch_name = "develop")
+#'   # Switch to "develop" branch and load packages
+#'   load_pkgs(branch_name = "develop")
 #'
-#' # Switch to the "develop" branch, pull the latest changes, and load packages
-#' load_pkgs(branch_name = "develop", git_pull = TRUE)
+#'   # Switch to the "develop" branch, pull the latest changes, and load packages
+#'   load_pkgs(branch_name = "develop", git_pull = TRUE)
 #'
-#' # Load packages from "develop" branch if available, or "main" branch otherwise
-#' # Pull the latest changes before loading the packages
-#' load_pkgs(branch_name = c("develop", "main"), git_pull = TRUE)
+#'   # Load packages from "develop" branch if available, or "main" branch otherwise
+#'   # Pull the latest changes before loading the packages
+#'   load_pkgs(branch_name = c("develop", "main"), git_pull = TRUE)
 #'
-#' # Load packages from specific commit
-#' from_commit <- list(packageA = "hash_commit")
-#' load_pkgs(branch_name = "main", git_pull = TRUE, from_commit = from_commit)
-#'
+#'   # Load packages from specific commit
+#'   from_commit <- list(packageA = "hash_commit")
+#'   load_pkgs(branch_name = "main", git_pull = TRUE, from_commit = from_commit)
 #' }
 #'
-load_pkgs <- function(branch_name = NULL, git_pull = FALSE, from_commit = list()) {
-
+load_pkgs <- function(
+    branch_name = NULL, git_pull = FALSE, from_commit = list(),
+    load_verbose = getOption("multiloadr.load.verbose", "warning")) {
   pkgs <- get_multiloadr_pkgs()
 
   if (is.null(pkgs)) {
@@ -59,7 +68,6 @@ load_pkgs <- function(branch_name = NULL, git_pull = FALSE, from_commit = list()
   }
 
   for (i in seq_along(pkgs)) {
-
     pkg <- names(pkgs)[i]
 
     path <- pkgs[[i]]
@@ -78,31 +86,50 @@ load_pkgs <- function(branch_name = NULL, git_pull = FALSE, from_commit = list()
       stdout = TRUE
     )
 
-    all_branches <- trimws(sub("origin\\/", "", sub("\\*", "", c(local_pkg_branches, remote_pkg_branches))))
+    all_branches <- trimws(
+      sub(
+        "origin\\/", "",
+        sub("\\*", "", c(local_pkg_branches, remote_pkg_branches))
+      )
+    )
 
     if (!is.null(branch_name)) {
       for (branch in branch_name) {
         if (branch %in% all_branches) {
           cat(
             paste0(
-              "\033[0;92m", branch, " branch exist in ",
-              pkg, "\033[0m\n"
+              "\033[0;92m", branch, " branch exist for \033[0m",
+              "\033[0;94m", pkg, "\033[0m\n"
             )
           )
 
-          system2(
+          checkout_error <- system2(
             "cd",
             args = c(path, paste("&& git checkout", branch)),
             stdout = FALSE,
             stderr = FALSE
           )
+          if (checkout_error) {
+            message <- paste(
+              "\033[0;91m`git checkout` failed.",
+              "Please check your local changes for\033[0;94m",
+              pkg, "\033[0m\n"
+            )
+            if (load_verbose == "error") {
+              stop(message)
+            } else if (load_verbose == "warning") {
+              warning(message)
+            } else if (load_verbose != "silent") {
+              cat(message)
+            }
+          }
 
           break
         } else {
           cat(
             paste0(
-              "\033[0;91m", branch, " branch doesn't exist in ",
-              pkg, "\033[0m\n"
+              "\033[0;91m", branch, " branch doesn't exist for \033[0m",
+              "\033[0;94m", pkg, "\033[0m\n"
             )
           )
         }
@@ -134,12 +161,26 @@ load_pkgs <- function(branch_name = NULL, git_pull = FALSE, from_commit = list()
         if (!check_remote) {
           cat("\033[0;96mRemote URL exists...\033[0m\n")
           cat("\033[0;96mPerforming git pull...\033[0m\n")
-          system2(
+          pull_error <- system2(
             "cd",
             args = c(path, "&& git pull"),
             stdout = FALSE,
             stderr = FALSE
           )
+          if (pull_error) {
+            message <- paste(
+              "\033[0;91m`git pull` failed.",
+              "Please check your local changes for\033[0;94m",
+              pkg, "\033[0m\n"
+            )
+            if (load_verbose == "error") {
+              stop(message)
+            } else if (load_verbose == "warning") {
+              warning(message)
+            } else if (load_verbose != "silent") {
+              cat(message)
+            }
+          }
         } else {
           cat("Remote URL does not exist...\n")
           cat("Skipping git pull...\n")

--- a/man/load_pkgs.Rd
+++ b/man/load_pkgs.Rd
@@ -4,19 +4,33 @@
 \alias{load_pkgs}
 \title{Load packages from specified branch and perform git pull if specified}
 \usage{
-load_pkgs(branch_name = NULL, git_pull = FALSE, from_commit = list())
+load_pkgs(
+  branch_name = NULL,
+  git_pull = FALSE,
+  from_commit = list(),
+  load_verbose = getOption("multiloadr.load.verbose", "warning")
+)
 }
 \arguments{
 \item{branch_name}{Character vector specifying the name of the git branch(es)
 to load. Defaults to \code{NULL}. The first branch that is found will be
 loaded for each package. If it is NULL or non-existent, it will be loaded
-from the presently active branch.}
+from the presently active branch.
+If local changes make checkout unsuccessful, the function will produce error.}
 
 \item{git_pull}{A logical value (TRUE/FALSE) indicating whether to perform a
-\verb{git pull} before loading the package. Defaults to \code{FALSE}.}
+\verb{git pull} before loading the package. Defaults to \code{FALSE}.
+If local changes make pull unsuccessful, the function will produce error.}
 
 \item{from_commit}{A named list indicating the commit hash to load for each
 package.}
+
+\item{load_verbose}{Default: \code{warning} A string that sets
+how should a pull/checkout failure be reported.
+\code{error} for stopping with an error,
+\code{warning} to show warning and continue,
+\code{message}/unset for just logging the git failure.
+Default value can be set with \code{options('multiloadr.load.verbose' = 'error')}.}
 }
 \value{
 This function returns nothing, but prints a message indicating which
@@ -35,26 +49,25 @@ branch that is found will be loaded for each package.
 }
 \examples{
 if (interactive()) {
-add_pkgs("packageA", "/path/to/packageA")
-add_pkgs("packageB", "/path/to/packageB")
+  add_pkgs("packageA", "/path/to/packageA")
+  add_pkgs("packageB", "/path/to/packageB")
 
-# Load packages without switching branch
-load_pkgs()
+  # Load packages without switching branch
+  load_pkgs()
 
-# Switch to "develop" branch and load packages
-load_pkgs(branch_name = "develop")
+  # Switch to "develop" branch and load packages
+  load_pkgs(branch_name = "develop")
 
-# Switch to the "develop" branch, pull the latest changes, and load packages
-load_pkgs(branch_name = "develop", git_pull = TRUE)
+  # Switch to the "develop" branch, pull the latest changes, and load packages
+  load_pkgs(branch_name = "develop", git_pull = TRUE)
 
-# Load packages from "develop" branch if available, or "main" branch otherwise
-# Pull the latest changes before loading the packages
-load_pkgs(branch_name = c("develop", "main"), git_pull = TRUE)
+  # Load packages from "develop" branch if available, or "main" branch otherwise
+  # Pull the latest changes before loading the packages
+  load_pkgs(branch_name = c("develop", "main"), git_pull = TRUE)
 
-# Load packages from specific commit
-from_commit <- list(packageA = "hash_commit")
-load_pkgs(branch_name = "main", git_pull = TRUE, from_commit = from_commit)
-
+  # Load packages from specific commit
+  from_commit <- list(packageA = "hash_commit")
+  load_pkgs(branch_name = "main", git_pull = TRUE, from_commit = from_commit)
 }
 
 }


### PR DESCRIPTION
Closes #9 

Changes:
The `load_pkgs` now checks for the status of the pull/checkout and log this for the user.
The user can choose if they need an `error`, `warning`, or `message` logged when git failure occurs. The default is `warning`.
This can also be set using an option in their `.Rprofile` using:
```r
options('multiloadr.load.verbose' = 'error') # stop with an error
options('multiloadr.load.verbose' = 'warning') # show a warning => default
options('multiloadr.load.verbose' = 'message') # show a message
```