### PR TITLE
Avoid mismatch between description and pkg_name

### DIFF
--- a/R/add_pkgs.R
+++ b/R/add_pkgs.R
@@ -18,6 +18,19 @@
 #'
 add_pkgs <- function(pkg_name, path) {
   multiloadr <- getOption("multiloadr", NULL)
+
+  desc <- read.dcf(file.path(path, "DESCRIPTION"))
+  pkg_name2 <- desc[, "Package"]
+
+  if (missing(pkg_name)) {
+    pkg_name <- pkg_name2
+  }
+  if (pkg_name != pkg_name2) {
+    stop("Package name does not match with the DESCRIPTION: ",
+         pkg_name, " != ", pkg_name2)
+  }
+
+
   new_entry <- setNames(list(path), noquote(pkg_name))
   pkg_exist <- pkg_name %in% names(multiloadr)
 


### PR DESCRIPTION
This patch makes possible to only use the path to add a package to multiloader records.

But more importantly it prevents a mismatch between pkg_name and the package added:

```r
add_pkgs(pkg_name = "teal.data", path = "../teal.modules.general")
Error in add_pkgs(pkg_name = "teal.data", path = "../teal.modules.general") : 
  Package name does not match with the DESCRIPTION: teal.data != teal.modules.general
```